### PR TITLE
Add create a new register feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/go
 gem 'openregister-ruby', git: 'https://github.com/robmckinnon/openregister-ruby.git'
 
 gem 'mongoid', git: 'https://github.com/mongodb/mongoid.git'
-gem 'mongoid-enum', git: 'https://github.com/robmckinnon/mongoid-enum.git'
 gem 'mongoid_slug', '>= 4.0.0'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -51,5 +51,9 @@ group :development do
   gem 'guard-rspec', require: false, git: 'https://github.com/robmckinnon/guard-rspec', branch: 'master'
 end
 
+group :test do
+  gem 'webmock'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,8 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     domain_name (0.5.20160310)
@@ -185,6 +187,7 @@ GEM
       shellany (~> 0.0)
       thor (>= 0.18.1)
     guard-compat (1.2.1)
+    hashdiff (0.3.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -263,6 +266,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -304,6 +308,10 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
+    webmock (2.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -344,6 +352,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
+  webmock
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,13 +24,6 @@ GIT
       guard-compat (~> 1.1)
 
 GIT
-  remote: https://github.com/robmckinnon/mongoid-enum.git
-  revision: b41661a7efef2428f98c964b0963be9f16022776
-  specs:
-    mongoid-enum (0.4.0)
-      mongoid (>= 5.0)
-
-GIT
   remote: https://github.com/robmckinnon/openregister-ruby.git
   revision: c2e7d73bb0c89cae49b85bf4717f3562b3aa8194
   specs:
@@ -333,7 +326,6 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   mongoid!
-  mongoid-enum!
   mongoid_slug (>= 4.0.0)
   openregister-ruby!
   puma (~> 3.0)

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -6,6 +6,7 @@ class RegistersController < ApplicationController
 
   def new
     @register = Register.new
+    @public_bodies = PublicBodies.new.call
   end
 
   def create
@@ -13,6 +14,7 @@ class RegistersController < ApplicationController
     if @register.save
       redirect_to action: :index
     else
+      @public_bodies = PublicBodies.new.call
       render :new
     end
   end

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -4,4 +4,24 @@ class RegistersController < ApplicationController
     @registers_by_phase = RegistersByPhase.new.call
   end
 
+  def new
+    @register = Register.new
+  end
+
+  def create
+    @register = RegisterCreate.new(register_params).call
+    if @register.save
+      redirect_to action: :index
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def register_params
+    params.require(:register).
+      permit(:register, :text, :registry, :phase)
+  end
+
 end

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -15,4 +15,12 @@ class Register
   validates :register, presence: true
   validates_inclusion_of :phase, in: PHASES, allow_blank: false
 
+  before_validation :parameterize_register_name
+
+  private
+
+  def parameterize_register_name
+    self.register = register.parameterize if register.present?
+  end
+
 end

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -2,17 +2,17 @@ class Register
 
   include Mongoid::Document
   include Mongoid::Timestamps
-  include Mongoid::Enum
+
+  PHASES = %w[proposed prospect discovery alpha beta live].freeze unless defined? PHASE
 
   field :register, type: String
   field :registry, type: String
   field :text, type: String
-
-  enum :phase, %i[proposed prospect discovery alpha beta live]
+  field :phase, type: String, default: PHASES.first
 
   index({ register: 1 }, unique: true, name: 'register_index')
 
   validates :register, presence: true
-  validates :phase, presence: true
+  validates_inclusion_of :phase, in: PHASES, allow_blank: false
 
 end

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -1,0 +1,18 @@
+class Register
+
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Enum
+
+  field :register, type: String
+  field :registry, type: String
+  field :text, type: String
+
+  enum :phase, %i[proposed prospect discovery alpha beta live]
+
+  index({ register: 1 }, unique: true, name: 'register_index')
+
+  validates :register, presence: true
+  validates :phase, presence: true
+
+end

--- a/app/services/public_bodies.rb
+++ b/app/services/public_bodies.rb
@@ -1,0 +1,20 @@
+class PublicBodies
+
+  def call
+    register = OpenRegister.register 'public-body', from_openregister: true
+    public_bodies = register._all_records
+    public_bodies.sort_by!(&:name)
+    public_bodies
+  rescue SocketError => e
+    if Rails.configuration.stub_registers_api_when_offline
+      Struct.new('PublicBody', :public_body, :name) unless defined? Stuct::PublicBody
+      [
+        Struct::PublicBody.new('cabinet-office', 'Cabinet Office'),
+        Struct::PublicBody.new('ministry-of-justice', 'Ministry of Justice')
+      ]
+    else
+      raise e
+    end
+  end
+
+end

--- a/app/services/public_bodies.rb
+++ b/app/services/public_bodies.rb
@@ -1,10 +1,12 @@
 class PublicBodies
 
   def call
-    register = OpenRegister.register 'public-body', from_openregister: true
-    public_bodies = register._all_records
-    public_bodies.sort_by!(&:name)
-    public_bodies
+    Rails.cache.fetch('public-bodies', expires_in: 1.day) do
+      register = OpenRegister.register 'public-body', from_openregister: true
+      public_bodies = register._all_records
+      public_bodies.sort_by!(&:name)
+      public_bodies
+    end
   rescue SocketError => e
     if Rails.configuration.stub_registers_api_when_offline
       Struct.new('PublicBody', :public_body, :name) unless defined? Stuct::PublicBody

--- a/app/services/register_create.rb
+++ b/app/services/register_create.rb
@@ -1,0 +1,11 @@
+class RegisterCreate
+
+  def initialize params
+    @params = params
+  end
+
+  def call
+    Register.new(@params)
+  end
+
+end

--- a/app/services/registers_by_phase.rb
+++ b/app/services/registers_by_phase.rb
@@ -1,6 +1,6 @@
 class RegistersByPhase
 
-  EMPTY = Rails.configuration.phases.each_with_object({}) do |phase, hash|
+  EMPTY = Register::PHASES.each_with_object({}) do |phase, hash|
     hash[phase] = []
   end.freeze unless defined? EMPTY
 

--- a/app/services/registers_by_phase.rb
+++ b/app/services/registers_by_phase.rb
@@ -5,7 +5,14 @@ class RegistersByPhase
   end.freeze unless defined? EMPTY
 
   def call
-    registers = OpenRegister.registers + OpenRegister.registers(from_openregister: true)
+    registers = Register.all.to_a
+
+    registers.push(
+      *OpenRegister.registers
+    ).push(
+      *OpenRegister.registers(from_openregister: true)
+    )
+
     registers.delete_if {|r| r.register.nil?}
     registers.sort_by!(&:register)
     by_phase = registers.group_by(&:phase)

--- a/app/services/registers_by_phase.rb
+++ b/app/services/registers_by_phase.rb
@@ -1,13 +1,21 @@
 class RegistersByPhase
 
+  EMPTY = Rails.configuration.phases.each_with_object({}) do |phase, hash|
+    hash[phase] = []
+  end.freeze unless defined? EMPTY
+
   def call
     registers = OpenRegister.registers + OpenRegister.registers(from_openregister: true)
     registers.delete_if {|r| r.register.nil?}
     registers.sort_by!(&:register)
     by_phase = registers.group_by(&:phase)
 
-    Rails.configuration.phases.each_with_object({}) do |phase, hash|
-      hash[phase] = by_phase[phase] || []
+    RegistersByPhase::EMPTY.merge(by_phase)
+  rescue SocketError => e
+    if Rails.configuration.stub_registers_api_when_offline
+      RegistersByPhase::EMPTY
+    else
+      raise e
     end
   end
 

--- a/app/views/registers/_form.html.slim
+++ b/app/views/registers/_form.html.slim
@@ -1,7 +1,11 @@
 == form_for @register do |f|
   = f.text_field :register
   = f.text_field :text
-  = f.text_field :registry
+  = f.text_field(:registry, class: 'awesomplete', list: 'public-bodies')
+  datalist#public-bodies
+    - @public_bodies.each do |b|
+      option value="#{b.public_body}"
+        = b.name
   .form-group
     = f.radio_button_fieldset :phase, inline: true, choices: Register::PHASE
   = f.submit class: 'button'

--- a/app/views/registers/_form.html.slim
+++ b/app/views/registers/_form.html.slim
@@ -1,0 +1,7 @@
+== form_for @register do |f|
+  = f.text_field :register
+  = f.text_field :text
+  = f.text_field :registry
+  .form-group
+    = f.radio_button_fieldset :phase, inline: true, choices: Register::PHASE
+  = f.submit class: 'button'

--- a/app/views/registers/_form.html.slim
+++ b/app/views/registers/_form.html.slim
@@ -7,5 +7,5 @@
       option value="#{b.public_body}"
         = b.name
   .form-group
-    = f.radio_button_fieldset :phase, inline: true, choices: Register::PHASE
+    = f.radio_button_fieldset :phase, inline: true, choices: Register::PHASES
   = f.submit class: 'button'

--- a/app/views/registers/index.html.slim
+++ b/app/views/registers/index.html.slim
@@ -10,7 +10,7 @@ h1.heading-xlarge
   .column-one-third
     = link_to "Create proposed register", new_register_path, class: 'button'
 .grid-row
-  - Rails.configuration.phases.each do |phase|
+  - Register::PHASES.each do |phase|
     - registers = @registers_by_phase[phase]
     .column-one-sixth
       = render partial: 'phase_count', locals: { count: registers.size, phase: phase }

--- a/app/views/registers/index.html.slim
+++ b/app/views/registers/index.html.slim
@@ -7,6 +7,9 @@ h1.heading-xlarge
 - #  Track registers progress.
 
 .grid-row
+  .column-one-third
+    = link_to "Create proposed register", new_register_path, class: 'button'
+.grid-row
   - Rails.configuration.phases.each do |phase|
     - registers = @registers_by_phase[phase]
     .column-one-sixth

--- a/app/views/registers/new.html.slim
+++ b/app/views/registers/new.html.slim
@@ -1,0 +1,6 @@
+- @page_title = 'Create new register proposal'
+
+h1.heading-xlarge
+  | Create new register
+
+== render partial: 'form'

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module Dashboard
 
     config.phases = %w[proposed prospect discovery alpha beta live]
 
+    config.stub_registers_api_when_offline = false
+
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,8 +22,6 @@ module Dashboard
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    config.phases = %w[proposed prospect discovery alpha beta live]
-
     config.stub_registers_api_when_offline = false
 
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,4 +40,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.stub_registers_api_when_offline = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,4 +33,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.cache_store = :memory_store
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,2 +1,21 @@
 en:
-  hello: "Hello world"
+  errors:
+    messages:
+      blank: is required
+  helpers:
+    fieldset:
+      register:
+        phase: What phase is this register?
+    label:
+      register:
+        register: Register name
+        text: Description
+        registry: Registry name
+    hint:
+      register:
+        register: |
+          e.g. public-body or food-premises-rating
+        text: |
+          Enter one line description
+        registry: |
+          e.g., cabinet-office or foreign-office

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
 
   resources :registers, only: [
       :index,
+      :new,
+      :create
     ]
 end

--- a/spec/features/create_register_proposals_spec.rb
+++ b/spec/features/create_register_proposals_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature "CreateRegisterProposals", type: :feature do
+
+  def valid_attributes overrides={}
+    {
+      register: 'country',
+      registry: 'foreign-commonwealth-office',
+      text: 'British English-language names and descriptive terms for countries',
+      phase: 'beta'
+    }.merge(overrides)
+  end
+
+  scenario 'submit new register form with valid parameters' do
+    visit new_register_path
+    attributes = valid_attributes
+    attributes.each do |field, value|
+      fill_in "register_#{field}", with: value unless field == :phase
+    end
+    choose attributes[:phase].capitalize
+    click_button 'Create Register'
+    expect(current_path).to eql(registers_path)
+  end
+
+  scenario 'submit new register form without parameters' do
+    visit new_register_path
+    click_button 'Create Register'
+    expect(page).to have_content('Register name is required')
+  end
+end

--- a/spec/features/create_register_proposals_spec.rb
+++ b/spec/features/create_register_proposals_spec.rb
@@ -17,7 +17,9 @@ RSpec.feature "CreateRegisterProposals", type: :feature do
   end
 
   scenario 'submit new register form with valid parameters' do
-    visit new_register_path
+    visit registers_path
+    click_on "Create proposed register"
+
     attributes = valid_attributes
     attributes.each do |field, value|
       fill_in "register_#{field}", with: value unless field == :phase

--- a/spec/features/create_register_proposals_spec.rb
+++ b/spec/features/create_register_proposals_spec.rb
@@ -11,6 +11,11 @@ RSpec.feature "CreateRegisterProposals", type: :feature do
     }.merge(overrides)
   end
 
+  before do
+    allow(RegistersByPhase).to receive(:new).and_return -> { RegistersByPhase::EMPTY }
+    allow(PublicBodies).to receive(:new).and_return -> { [] }
+  end
+
   scenario 'submit new register form with valid parameters' do
     visit new_register_path
     attributes = valid_attributes
@@ -19,7 +24,7 @@ RSpec.feature "CreateRegisterProposals", type: :feature do
     end
     choose attributes[:phase].capitalize
     click_button 'Create Register'
-    expect(current_path).to eql(registers_path)
+    expect(current_path).to eql(root_path)
   end
 
   scenario 'submit new register form without parameters' do

--- a/spec/models/register_spec.rb
+++ b/spec/models/register_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Register, type: :model do
   it 'is invalid when register blank' do
     register = described_class.new valid_attributes(register: nil)
     expect(register).not_to be_valid
-    expect(register.errors.full_messages).to eq ["Register can't be blank"]
+    expect(register.errors.full_messages).to eq ["Register is required"]
   end
 
   it 'defaults phase to :proposed when phase not provided' do

--- a/spec/models/register_spec.rb
+++ b/spec/models/register_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Register, type: :model do
 
   def valid_attributes overrides={}
     {
-      register: 'country',
+      register: 'ISO Country',
       registry: 'foreign-commonwealth-office',
       text: 'British English-language names and descriptive terms for countries',
       phase: 'beta'
@@ -14,6 +14,12 @@ RSpec.describe Register, type: :model do
   it 'creates with valid attributes' do
     register = described_class.new valid_attributes
     expect(register).to be_valid
+  end
+
+  it 'converts register name to dashed lowercase string' do
+    register = described_class.new valid_attributes
+    register.valid?
+    expect(register.register).to eq 'iso-country'
   end
 
   it 'stores phase as string' do

--- a/spec/models/register_spec.rb
+++ b/spec/models/register_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Register, type: :model do
+
+  def valid_attributes overrides={}
+    {
+      register: 'country',
+      registry: 'foreign-commonwealth-office',
+      text: 'British English-language names and descriptive terms for countries',
+      phase: 'beta'
+    }.merge(overrides)
+  end
+
+  it 'creates with valid attributes' do
+    register = described_class.new valid_attributes
+    expect(register).to be_valid
+  end
+
+  it 'changes phase to symbol' do
+    register = described_class.new valid_attributes
+    expect(register.phase).to eq :beta
+  end
+
+  it 'is invalid when register blank' do
+    register = described_class.new valid_attributes(register: nil)
+    expect(register).not_to be_valid
+    expect(register.errors.full_messages).to eq ["Register can't be blank"]
+  end
+
+  it 'defaults phase to :proposed when phase not provided' do
+    register = described_class.new valid_attributes.except(:phase)
+    expect(register.phase).to eq :proposed
+  end
+end

--- a/spec/models/register_spec.rb
+++ b/spec/models/register_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Register, type: :model do
     expect(register).to be_valid
   end
 
-  it 'changes phase to symbol' do
+  it 'stores phase as string' do
     register = described_class.new valid_attributes
-    expect(register.phase).to eq :beta
+    expect(register.phase).to eq 'beta'
   end
 
   it 'is invalid when register blank' do
@@ -27,8 +27,8 @@ RSpec.describe Register, type: :model do
     expect(register.errors.full_messages).to eq ["Register is required"]
   end
 
-  it 'defaults phase to :proposed when phase not provided' do
+  it 'defaults phase to "proposed" when phase not provided' do
     register = described_class.new valid_attributes.except(:phase)
-    expect(register.phase).to eq :proposed
+    expect(register.phase).to eq 'proposed'
   end
 end

--- a/spec/services/public_bodies_spec.rb
+++ b/spec/services/public_bodies_spec.rb
@@ -3,13 +3,26 @@ require 'openregister'
 
 RSpec.describe PublicBodies do
 
-  let(:cabinet_office) { double(name: 'Cabinet Office') }
-  let(:moj) { double(name: 'Ministry of Justice') }
+  Struct.new('PublicBody', :public_body, :name) unless defined? Stuct::PublicBody
+
+  let(:cabinet_office) { Struct::PublicBody.new('cabinet-office', 'Cabinet Office') }
+  let(:moj) { Struct::PublicBody.new('ministry-of-justice', 'Ministry of Justice') }
   let(:register) { double(_all_records: [moj, cabinet_office]) }
+
+  after { Rails.cache.clear }
 
   it 'returns public bodies from API calls ordered by name' do
     expect(OpenRegister).to receive(:register).and_return register
 
     expect(PublicBodies.new.call).to eq([cabinet_office, moj])
   end
+
+  it 'returns public bodies from cache when called a second time' do
+    expect(OpenRegister).to receive(:register).and_return register
+    PublicBodies.new.call
+
+    expect(OpenRegister).not_to receive(:register)
+    expect(PublicBodies.new.call).to eq([cabinet_office, moj])
+  end
+
 end

--- a/spec/services/public_bodies_spec.rb
+++ b/spec/services/public_bodies_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+require 'openregister'
+
+RSpec.describe PublicBodies do
+
+  let(:cabinet_office) { double(name: 'Cabinet Office') }
+  let(:moj) { double(name: 'Ministry of Justice') }
+  let(:register) { double(_all_records: [moj, cabinet_office]) }
+
+  it 'returns public bodies from API calls ordered by name' do
+    expect(OpenRegister).to receive(:register).and_return register
+
+    expect(PublicBodies.new.call).to eq([cabinet_office, moj])
+  end
+end

--- a/spec/services/register_create_spec.rb
+++ b/spec/services/register_create_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+require 'openregister'
+
+RSpec.describe RegisterCreate do
+
+  let(:params) { double }
+
+  it 'creates new Register from params' do
+    register = double
+    expect(Register).to receive(:new).with(params).and_return register
+    expect(described_class.new(params).call).to eq register
+  end
+end

--- a/spec/services/registers_by_phase_spec.rb
+++ b/spec/services/registers_by_phase_spec.rb
@@ -2,22 +2,32 @@ require 'rails_helper'
 require 'openregister'
 
 RSpec.describe RegistersByPhase do
-  let(:beta_register) { double(register: 'country', phase: 'beta') }
+  let(:beta_register) { double(register: 'school', phase: 'beta') }
   let(:alpha_register) { double(register: 'address', phase: 'alpha') }
+
+  let(:persisted_register) do
+    Register.new(
+      register: 'country',
+      registry: 'foreign-commonwealth-office',
+      text: 'British English-language names and descriptive terms for countries',
+      phase: 'beta'
+    )
+  end
 
   it 'returns registers from API calls grouped by phase' do
     expect(OpenRegister).to receive(:registers).and_return [beta_register]
     expect(OpenRegister).to receive(:registers).with(from_openregister: true).and_return [alpha_register]
+    expect(Register).to receive(:all).and_return [persisted_register]
 
     x = RegistersByPhase.new
     y = x.call
     expect(y).to eq({
-      "alpha" => [alpha_register],
-      "beta" => [beta_register],
-      "discovery" => [],
-      "live" => [],
-      "proposed" => [],
-      "prospect" => [],
+      'proposed' => [],
+      'prospect' => [],
+      'discovery' => [],
+      'alpha' => [alpha_register],
+      'beta' => [persisted_register, beta_register],
+      'live' => [],
     })
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'webmock/rspec'
+
 RSpec.configure do |config|
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
- Add form for creating a new register that redirects to index page on success.
- Show validation error on form when it is submitted with invalid data.
- Enable user to select `registry` field from a list of public bodies retrieved from the `public-bodies` register.
- Show proposed registers on the dashboard view.
