### PR TITLE
Remove edit link from registers retrieved via API

### DIFF
--- a/app/views/registers/_register.html.slim
+++ b/app/views/registers/_register.html.slim
@@ -1,6 +1,9 @@
 .register
   h3.heading-small
-    = link_to register.register, edit_register_path(register)
+    - if register.try(:persisted?)
+      = link_to register.register, edit_register_path(register)
+    - else
+      = register.register
   - if false # register._from_openregister
     p
       span.domain


### PR DESCRIPTION
Prevent edit link being created for registers on dashboard that were retrieved from the register's API, as they do not yet have entries in the app's data store.