### PR TITLE
Add register show view, link to from dashboard

### DIFF
--- a/app/assets/stylesheets/govuk_elements.sass
+++ b/app/assets/stylesheets/govuk_elements.sass
@@ -123,3 +123,33 @@ $prospect-colour: $purple
   @extend .heading-small
   font-weight: bold
 
+// Phase circle
+// ==========================================================================
+
+.related-container
+  margin-top: 30px
+
+.phase-circle
+  width: 40%
+  position: relative
+
+.circle-label
+  position: absolute
+  top: 50%
+  left: 0px
+  width: 100%
+  margin-top: -15px
+  text-align: center
+  color: $page-colour
+  font-weight: 700
+  font-size: 24px
+
+.circle
+  background: $grey-1
+  color: $page-colour
+  width: 100%
+  height: 0px
+  padding-top: 100%
+  border-radius: 50% 50%
+  display: inline-block
+  margin: 0px

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -31,7 +31,7 @@ class RegistersController < ApplicationController
   def update
     @register = RegisterUpdate.new(params[:id], register_params).call
     if !@register.try(:changed?)
-      redirect_to action: :index
+      redirect_to action: :show, id: params[:id]
     else
       @public_bodies = PublicBodies.new.call
       render :edit

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -19,6 +19,10 @@ class RegistersController < ApplicationController
     end
   end
 
+  def show
+    @register = Register.find(params[:id])
+  end
+
   def edit
     @register = Register.find(params[:id])
     @public_bodies = PublicBodies.new.call

--- a/app/views/registers/_register.html.slim
+++ b/app/views/registers/_register.html.slim
@@ -1,7 +1,7 @@
 .register
   h3.heading-small
     - if register.try(:persisted?)
-      = link_to register.register, edit_register_path(register)
+      = link_to register.register, register_path(register)
     - else
       = register.register
   - if false # register._from_openregister

--- a/app/views/registers/show.html.slim
+++ b/app/views/registers/show.html.slim
@@ -1,0 +1,8 @@
+- @page_title = "#{@register.register.capitalize} Register"
+
+.grid-row
+
+  .column-two-thirds
+    h1.heading-xlarge= @page_title
+
+    = link_to t('register.edit', scope: 'helpers.submit'), edit_register_path(@register), class: 'button'

--- a/app/views/registers/show.html.slim
+++ b/app/views/registers/show.html.slim
@@ -1,8 +1,21 @@
 - @page_title = "#{@register.register.capitalize} Register"
 
 .grid-row
-
   .column-two-thirds
     h1.heading-xlarge= @page_title
+    p.lede= @register.text
 
-    = link_to t('register.edit', scope: 'helpers.submit'), edit_register_path(@register), class: 'button'
+  .column-third
+    aside#related
+      .related-container
+        .group
+          .phase-circle
+            p class="circle #{@register.phase} phase"
+            p.circle-label= @register.phase.capitalize
+          h4.heading-small Registry
+          p= @register.registry
+
+.grid-row
+  .column-two-thirds
+    p= link_to t('register.edit', scope: 'helpers.link'), edit_register_path(@register), class: 'button'
+    p= link_to t('register.index', scope: 'helpers.link'), registers_path, class: 'link-back'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,9 +19,12 @@ en:
           Enter one line description
         registry: |
           e.g., cabinet-office or foreign-office
+    link:
+      register:
+        edit: Edit register entry
+        index: Return to dashboard
     submit:
       cancel: Cancel
       register:
         create: Create register entry
-        edit: Edit register entry
         update: Update register entry

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,4 +23,5 @@ en:
       cancel: Cancel
       register:
         create: Create register entry
+        edit: Edit register entry
         update: Update register entry

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       :index,
       :new,
       :create,
+      :show,
       :edit,
       :update,
     ]

--- a/spec/features/create_register_entry_spec.rb
+++ b/spec/features/create_register_entry_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'openregister'
 
-RSpec.feature "CreateRegisterProposals", type: :feature do
+RSpec.feature "CreateRegisterEntry", type: :feature do
 
   before do
     allow(OpenRegister).to receive(:registers).and_return []

--- a/spec/features/edit_register_entry_spec.rb
+++ b/spec/features/edit_register_entry_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "EditRegisterEntry", type: :feature do
   scenario 'update register entry with valid parameters' do
     given_a_user_chooses_to_edit_a_register_entry
     when_they_update_with_valid_parameters
-    then_they_see_register_on_dashboard_with_changed_parameters
+    then_they_see_register_entry_with_changed_parameters
   end
 
   scenario 'update register entry with invalid parameters' do
@@ -37,17 +37,16 @@ RSpec.feature "EditRegisterEntry", type: :feature do
 
   def when_they_update_with_valid_parameters
     within 'form.edit_register' do
-      attributes = valid_attributes
-      attributes.each do |field, value|
-        fill_in "register_#{field}", with: value unless field == :phase
-      end
       choose 'Live'
       click_update
     end
   end
 
-  def then_they_see_register_on_dashboard_with_changed_parameters
-    expect(current_path).to eql(root_path)
+  def then_they_see_register_entry_with_changed_parameters
+    expect(current_path).to eql(register_path(Register.last))
+    within('.phase-circle') do
+      expect(page).to have_content('Live')
+    end
   end
 
   def when_they_update_with_invalid_parameters

--- a/spec/features/edit_register_entry_spec.rb
+++ b/spec/features/edit_register_entry_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'openregister'
 
-RSpec.feature "EditRegisterProposal", type: :feature do
+RSpec.feature "EditRegisterEntry", type: :feature do
 
   before do
     allow(OpenRegister).to receive(:registers).and_return []

--- a/spec/features/edit_register_proposal_spec.rb
+++ b/spec/features/edit_register_proposal_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "EditRegisterProposal", type: :feature do
     RegisterCreate.new(valid_attributes).call
     visit registers_path
     click_on "country"
+    click_on "Edit register entry"
   end
 
   def when_they_update_with_valid_parameters

--- a/spec/features/show_register_entry_spec.rb
+++ b/spec/features/show_register_entry_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+require 'openregister'
+
+RSpec.feature "ShowRegisterEntry", type: :feature do
+
+  before do
+    allow(OpenRegister).to receive(:registers).and_return []
+    allow(PublicBodies).to receive(:new).and_return -> { [] }
+  end
+
+  after { Register.all.each(&:destroy) }
+
+  scenario 'view register entry and return to dashboard' do
+    given_a_user_sees_a_register_entry_on_dashboard
+    when_they_choose_to_view_the_register_entry
+    then_they_see_register_entry_details
+
+    when_they_choose_to_return_to_dashboard
+    then_they_see_register_dashboard
+  end
+
+  def given_a_user_sees_a_register_entry_on_dashboard
+    RegisterCreate.new(valid_attributes).call
+    visit registers_path
+    within '#content' do
+      expect(page).to have_content("country")
+    end
+  end
+
+  def when_they_choose_to_view_the_register_entry
+    click_on "country"
+  end
+
+  def then_they_see_register_entry_details
+    within '#content' do
+      valid_attributes.each do |key, value|
+        value = value.capitalize unless [:registry, :text].include?(key)
+        expect(page).to have_content(value)
+      end
+    end
+  end
+
+  def when_they_choose_to_return_to_dashboard
+    within('#content') do
+      click_on 'Return to dashboard'
+    end
+  end
+
+  def then_they_see_register_dashboard
+    expect(current_path).to eql(registers_path)
+  end
+
+  def valid_attributes overrides={}
+    {
+      register: 'country',
+      registry: 'foreign-commonwealth-office',
+      text: 'British English-language names and descriptive terms for countries',
+      phase: 'beta'
+    }.merge(overrides)
+  end
+
+end


### PR DESCRIPTION
- Link to register show views from register entries on dashboard.
- Show register fields on show view, including phase styled in a circle.
- On register show view, add links to edit register, and to return to dashboard.