### PR TITLE
Show discovery registers in dashboard table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GIT
 
 GIT
   remote: https://github.com/robmckinnon/openregister-ruby.git
-  revision: fdc1357720b25465ccb9e4731a1b29304ba0b3f4
+  revision: 6e0eab4abf4b72441f14c67da5da7344a6b01a98
   specs:
     openregister-ruby (0.0.1)
       morph (~> 0.4.1)
@@ -153,7 +153,7 @@ GEM
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
-    domain_name (0.5.20160310)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -198,7 +198,7 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (2.99.1)
+    mime-types (2.99.2)
     mini_portile2 (2.0.0)
     minitest (5.9.0)
     mongo (2.2.5)

--- a/app/services/public_bodies.rb
+++ b/app/services/public_bodies.rb
@@ -2,7 +2,7 @@ class PublicBodies
 
   def call
     Rails.cache.fetch('public-bodies', expires_in: 1.day) do
-      register = OpenRegister.register 'public-body', from_openregister: true
+      register = OpenRegister.register 'public-body', :alpha
       public_bodies = register._all_records
       public_bodies.sort_by!(&:name)
       public_bodies

--- a/app/services/registers_by_phase.rb
+++ b/app/services/registers_by_phase.rb
@@ -20,7 +20,7 @@ class RegistersByPhase
     registers.push(
       *OpenRegister.registers
     ).push(
-      *OpenRegister.registers(from_openregister: true)
+      *OpenRegister.registers(:alpha)
     )
     registers.delete_if {|r| r.register.nil?}
     registers

--- a/app/services/registers_by_phase.rb
+++ b/app/services/registers_by_phase.rb
@@ -21,6 +21,8 @@ class RegistersByPhase
       *OpenRegister.registers
     ).push(
       *OpenRegister.registers(:alpha)
+    ).push(
+      *OpenRegister.registers(:discovery)
     )
     registers.delete_if {|r| r.register.nil?}
     registers

--- a/spec/features/show_register_entry_spec.rb
+++ b/spec/features/show_register_entry_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "ShowRegisterEntry", type: :feature do
     allow(OpenRegister).to receive(:registers).and_return [
       double(attributes(register: 'api-country', _uri: 'http://country.register/'))
     ]
-    allow(OpenRegister).to receive(:registers).with(from_openregister: true).and_return []
+    allow(OpenRegister).to receive(:registers).with(:alpha).and_return []
     allow(PublicBodies).to receive(:new).and_return -> { [] }
   end
 

--- a/spec/features/show_register_entry_spec.rb
+++ b/spec/features/show_register_entry_spec.rb
@@ -4,10 +4,11 @@ require 'openregister'
 RSpec.feature "ShowRegisterEntry", type: :feature do
 
   before do
-    allow(OpenRegister).to receive(:registers).and_return [
+    allow(OpenRegister).to receive(:registers).with(no_args).and_return [
       double(attributes(register: 'api-country', _uri: 'http://country.register/'))
     ]
     allow(OpenRegister).to receive(:registers).with(:alpha).and_return []
+    allow(OpenRegister).to receive(:registers).with(:discovery).and_return []
     allow(PublicBodies).to receive(:new).and_return -> { [] }
   end
 

--- a/spec/services/registers_by_phase_spec.rb
+++ b/spec/services/registers_by_phase_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe RegistersByPhase do
   it 'returns registers from API calls grouped by phase' do
     expect(OpenRegister).to receive(:registers).and_return [beta_register]
     expect(OpenRegister).to receive(:registers).with(:alpha).and_return [alpha_register]
+    expect(OpenRegister).to receive(:registers).with(:discovery).and_return []
     expect(Register).to receive(:all).and_return [persisted_register]
 
     x = RegistersByPhase.new

--- a/spec/services/registers_by_phase_spec.rb
+++ b/spec/services/registers_by_phase_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RegistersByPhase do
 
   it 'returns registers from API calls grouped by phase' do
     expect(OpenRegister).to receive(:registers).and_return [beta_register]
-    expect(OpenRegister).to receive(:registers).with(from_openregister: true).and_return [alpha_register]
+    expect(OpenRegister).to receive(:registers).with(:alpha).and_return [alpha_register]
     expect(Register).to receive(:all).and_return [persisted_register]
 
     x = RegistersByPhase.new


### PR DESCRIPTION
* Update openregister-ruby gem and usage.
* Add registers from discovery phase domain to list of registers to display on dashboard.